### PR TITLE
polls url include must be before cms url include

### DIFF
--- a/Step 3 - CMS Plugins.md
+++ b/Step 3 - CMS Plugins.md
@@ -41,6 +41,13 @@ Add the following line to the project's `urls.py`:
 url(r'^polls/', include('polls.urls', namespace='polls')),
 ```
 
+Make sure this line before the line for the django-cms urls, or else django-cms will try to interperet the polls url as a slug, fail, and return a 404.
+
+```python
+url(r'^polls/', include('polls.urls', namespace='polls')),
+url(r'^', include('cms.urls')),
+```
+
 Now run the migrations using south.
 
 ```bash


### PR DESCRIPTION
In Step 3, we tell users to add the following line to their project's
urls.py:
url(r'^polls/', include('polls.urls', namespace='polls')),

However, if they add it to the end, then django-cms will first modify the path
of the url from '/en/polls/' to '/en/polls/$'.
See https://github.com/divio/django-cms/blob/develop/cms/views.py#L40
This only manifests itself as an opaque 404, frustrating someone who is
following along with the tutorial and does not know why the newly-added
polls application fails to show up. I personally found this confusing until I
dove into the source of django's url routing with pdb, walked up a stack frame,
and found the referenced line of django-cms.
