### PR TITLE
Only choose from what's offered or you'll still suffer from "atomic transactions"

### DIFF
--- a/Step 1 - Initial Setup.md
+++ b/Step 1 - Initial Setup.md
@@ -64,7 +64,7 @@ Feel free to answer the questions to your liking, but please note that this tuto
 $ djangocms -p . mysite
 Database configuration (in URL format) [default sqlite://localhost/project.db]:
 django CMS version (choices: 2.4, 3.0, stable, develop) [default stable]:
-Django version (choices: 1.4, 1.5, 1.6, stable) [default stable]: 1.5.8
+Django version (choices: 1.4, 1.5, 1.6, stable) [default stable]: 1.5
 Activate Django I18N / L10N setting (choices: yes, no) [default yes]:
 Install and configure reversion support (choices: yes, no) [default yes]:
 Languages to enable. Option can be provided multiple times, or as a comma separated list: en,de


### PR DESCRIPTION
Typing "1.5.8" will give you Django 1.6.x, anyway, presumably because "1.5.8" isn't any of the listed choices, so it's falling back to the default. (It'd be much nicer if the installer would abort on invalid input, but apparently, it doesn't.) Typing just "1.5" will give us Django 1.5.x, thereby working around the "atomic transactions" problem mentioned in 2243f26bd2397abc9282f9c64957eb3bdc14656f
