### PR TITLE
Update Step 4 - Add app_name attribute

### DIFF
--- a/Step 4 - CMS Apps.md
+++ b/Step 4 - CMS Apps.md
@@ -19,6 +19,7 @@ from django.utils.translation import ugettext_lazy as _
 class PollsApp(CMSApp):
     name = _("Poll App")  # give your app a name, this is required
     urls = ["polls.urls"]  # link your app to url configuration(s)
+    app_name = "polls"
 
 apphook_pool.register(PollsApp)  # register your app
 ```


### PR DESCRIPTION
Latest django-polls from pip uses the 'polls' namespace to display the poll app. 
 From polls/templates/index.html:

``` html
    <li><a href="{% url 'polls:detail' poll.id %}">{{ poll.question }}</a></li>
```

Unless you set the 'app_name' to 'polls', the example in the tutorial won't work.
